### PR TITLE
Add support for list of roles, string roles and fix "all fields" policies

### DIFF
--- a/lib/ash_rbac.ex
+++ b/lib/ash_rbac.ex
@@ -1,4 +1,6 @@
 defmodule AshRbac do
+  @role_type {:or, [:atom, :string, {:list, {:or, [:atom, :string]}}]}
+
   @role %Spark.Dsl.Entity{
     name: :role,
     describe: "If the check is true, the request is forbidden, otherwise run remaining checks.",
@@ -7,7 +9,7 @@ defmodule AshRbac do
     links: [],
     schema: [
       role: [
-        type: :atom,
+        type: @role_type,
         required: true,
         doc: """
         The role this config is for
@@ -55,7 +57,7 @@ defmodule AshRbac do
     ],
     schema: [
       bypass: [
-        type: :atom,
+        type: @role_type,
         doc: "Role that is allowed to bypass authorization"
       ],
       public?: [

--- a/test/support/policy.ex
+++ b/test/support/policy.ex
@@ -112,13 +112,48 @@ defmodule PolicyTestSupport do
     end
   end
 
+  defmodule SharedResource do
+    @moduledoc false
+    use Ash.Resource,
+      data_layer: Ash.DataLayer.Ets,
+      authorizers: [Ash.Policy.Authorizer],
+      extensions: [AshRbac]
+
+    ets do
+      private?(true)
+    end
+
+    rbac do
+      bypass :super_admin
+
+      role [:admin, "admin"] do
+        fields [:*]
+        actions [:create, :read]
+      end
+    end
+
+    actions do
+      defaults([:create, :read, :update, :destroy])
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+
+      attribute(:basic_field, :integer, default: 2)
+
+      create_timestamp(:created_at, private?: false)
+      update_timestamp(:updated_at, private?: false)
+    end
+  end
+
   defmodule Registry do
     @moduledoc false
     use Ash.Registry
 
     entries do
-      entry(RootResource)
-      entry(ChildResource)
+      entry RootResource
+      entry ChildResource
+      entry SharedResource
     end
   end
 


### PR DESCRIPTION
This PR contains three things:
1. It fixes `:*` field policies, because they were not working
2. It adds support for roles that are strings
3. It adds support for list of roles, in case where two roles have the same permissions for to a resource