### PR TITLE
Do not add empty policies

### DIFF
--- a/lib/ash_rbac/policies.ex
+++ b/lib/ash_rbac/policies.ex
@@ -13,18 +13,23 @@ defmodule AshRbac.Policies do
     {field_settings, action_settings} = transform_options(dsl_state)
     bypass = Info.bypass(dsl_state)
 
-    {:ok,
-     case Info.public?(dsl_state) do
-       false ->
-         dsl_state
-         |> add_field_policies(field_settings)
-         |> add_action_policies(action_settings)
-         |> add_bypass(bypass)
+    dsl_state =
+      cond do
+        {field_settings, action_settings} == {%{}, %{}} ->
+          dsl_state
 
-       true ->
-         dsl_state
-         |> add_allow_policy()
-     end}
+        Info.public?(dsl_state) ->
+          dsl_state
+          |> add_allow_policy()
+
+        true ->
+          dsl_state
+          |> add_field_policies(field_settings)
+          |> add_action_policies(action_settings)
+          |> add_bypass(bypass)
+      end
+
+    {:ok, dsl_state}
   end
 
   defp transform_options(dsl_state) do


### PR DESCRIPTION
This PR skips adding `field_policies` if there's no `rbac` block in the resource's DSL. I've added that because when adding Rbac extension to `__using__` block of a `MyApp.Resource` compilation failes do to missing `field_policies` for some fields and this would force devs to add 
```elixir
    field_policy :* do
      authorize_if always()
    end
```
to each resource.