### PR TITLE
feat: Adds support for other roles fields

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -5,6 +5,7 @@ spark_locals_without_parens = [
   rbac: 1,
   public?: 1,
   bypass: 1,
+  roles_field: 1,
   role: 2
 ]
 

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -5,6 +5,7 @@ spark_locals_without_parens = [
   rbac: 1,
   public?: 1,
   bypass: 1,
+  bypass_roles_field: 1,
   roles_field: 1,
   role: 2
 ]

--- a/lib/ash_rbac.ex
+++ b/lib/ash_rbac.ex
@@ -5,7 +5,7 @@ defmodule AshRbac do
     name: :role,
     describe: "If the check is true, the request is forbidden, otherwise run remaining checks.",
     target: AshRbac.Role,
-    args: [:role],
+    args: [:role, {:optional, :options}],
     links: [],
     schema: [
       role: [
@@ -13,6 +13,13 @@ defmodule AshRbac do
         required: true,
         doc: """
         The role this config is for
+        """
+      ],
+      options: [
+        type: :keyword_list,
+        required: false,
+        doc: """
+        The options this config is for
         """
       ],
       fields: [

--- a/lib/ash_rbac.ex
+++ b/lib/ash_rbac.ex
@@ -67,6 +67,11 @@ defmodule AshRbac do
         type: @role_type,
         doc: "Role that is allowed to bypass authorization"
       ],
+      bypass_roles_field: [
+        type: :atom,
+        required: false,
+        doc: "The actor roles field name for the bypass"
+      ],
       public?: [
         type: :boolean,
         doc: "Allow all access",
@@ -86,6 +91,10 @@ defmodule AshRbac do
 
     def bypass(resource) do
       Extension.get_opt(resource, [:rbac], :bypass, nil)
+    end
+
+    def bypass_roles_field(resource) do
+      Extension.get_opt(resource, [:rbac], :bypass_roles_field, :roles)
     end
 
     def public?(resource) do

--- a/lib/ash_rbac.ex
+++ b/lib/ash_rbac.ex
@@ -5,7 +5,7 @@ defmodule AshRbac do
     name: :role,
     describe: "If the check is true, the request is forbidden, otherwise run remaining checks.",
     target: AshRbac.Role,
-    args: [:role, {:optional, :options}],
+    args: [:role],
     links: [],
     schema: [
       role: [
@@ -15,11 +15,11 @@ defmodule AshRbac do
         The role this config is for
         """
       ],
-      options: [
-        type: :keyword_list,
+      roles_field: [
+        type: :atom,
         required: false,
         doc: """
-        The options this config is for
+        The actor roles field name
         """
       ],
       fields: [

--- a/lib/ash_rbac/has_role.ex
+++ b/lib/ash_rbac/has_role.ex
@@ -7,14 +7,13 @@ defmodule AshRbac.HasRole do
   @impl true
   def describe(options) do
     options[:role]
-    |> Enum.map(fn {roles_field, roles} ->
+    |> Enum.map_join(" or ", fn {roles_field, roles} ->
       if Enum.count(roles) > 1 do
         "any of the roles #{inspect(roles)} for field #{inspect(roles_field)}"
       else
         "the role #{inspect(Enum.at(roles, 0))} for field #{inspect(roles_field)}"
       end
     end)
-    |> Enum.join(" or ")
     |> then(&"Checks if the actor has #{&1}")
   end
 

--- a/lib/ash_rbac/has_role.ex
+++ b/lib/ash_rbac/has_role.ex
@@ -15,7 +15,7 @@ defmodule AshRbac.HasRole do
       end
     end)
     |> Enum.join(" or ")
-    |> then(& "Checks if the actor has #{&1}")
+    |> then(&"Checks if the actor has #{&1}")
   end
 
   @impl true

--- a/lib/ash_rbac/has_role.ex
+++ b/lib/ash_rbac/has_role.ex
@@ -6,24 +6,33 @@ defmodule AshRbac.HasRole do
 
   @impl true
   def describe(options) do
-    if is_list(options[:role]) do
-      "Checks if the actor has any of the roles #{inspect(options[:role])}"
-    else
-      "Checks if the actor has the role #{inspect(options[:role])}"
-    end
+    options[:role]
+    |> Enum.map(fn {roles_field, roles} ->
+      if Enum.count(roles) > 1 do
+        "any of the roles #{inspect(roles)} for field #{inspect(roles_field)}"
+      else
+        "the role #{inspect(Enum.at(roles, 0))} for field #{inspect(roles_field)}"
+      end
+    end)
+    |> Enum.join(" or ")
+    |> then(& "Checks if the actor has #{&1}")
   end
 
   @impl true
   def match?(actor, _, options) do
-    match(options[:role], actor)
+    Enum.any?(options[:role], fn {roles_field, role} ->
+      match(role, actor, roles_field)
+    end)
   end
 
-  defp match(roles, actor) when is_list(roles) do
-    roles -- roles(actor) != roles
+  defp match(roles, actor, roles_field) when is_list(roles) do
+    roles -- roles(actor, roles_field) != roles
   end
 
-  defp match(roles, actor), do: match([roles], actor)
+  defp match(roles, actor, roles_field), do: match([roles], actor, roles_field)
 
-  defp roles(%{roles: roles}) when is_list(roles), do: roles
+  defp roles(actor, roles_field), do: actor |> Map.get(roles_field) |> roles()
+
+  defp roles(roles) when is_list(roles), do: roles
   defp roles(_), do: []
 end

--- a/lib/ash_rbac/policies.ex
+++ b/lib/ash_rbac/policies.ex
@@ -40,7 +40,12 @@ defmodule AshRbac.Policies do
         %{entity | role: role}
       end)
     end)
-    |> Enum.reduce({%{}, %{}}, fn %{role: role, fields: fields, roles_field: roles_field, actions: actions},
+    |> Enum.reduce({%{}, %{}}, fn %{
+                                    role: role,
+                                    fields: fields,
+                                    roles_field: roles_field,
+                                    actions: actions
+                                  },
                                   {field_settings, action_settings} ->
       roles_field = roles_field || :roles
 
@@ -62,6 +67,7 @@ defmodule AshRbac.Policies do
               [{role, roles_field} | roles]
             end)
         end)
+
       {
         field_settings,
         actions

--- a/lib/ash_rbac/policies.ex
+++ b/lib/ash_rbac/policies.ex
@@ -40,9 +40,9 @@ defmodule AshRbac.Policies do
         %{entity | role: role}
       end)
     end)
-    |> Enum.reduce({%{}, %{}}, fn %{role: role, fields: fields, options: options, actions: actions},
+    |> Enum.reduce({%{}, %{}}, fn %{role: role, fields: fields, roles_field: roles_field, actions: actions},
                                   {field_settings, action_settings} ->
-      roles_field = get_option(options, :roles_field, :roles)
+      roles_field = roles_field || :roles
 
       field_settings =
         fields
@@ -77,9 +77,6 @@ defmodule AshRbac.Policies do
       {group_field_settings(field_settings, all_fields), action_settings}
     end)
   end
-
-  defp get_option(nil, _, default), do: default
-  defp get_option(options, key, default), do: Keyword.get(options, key, default)
 
   defp group_field_settings(field_settings, all_fields) do
     policy_fields = Map.keys(field_settings)

--- a/lib/ash_rbac/policies.ex
+++ b/lib/ash_rbac/policies.ex
@@ -13,6 +13,7 @@ defmodule AshRbac.Policies do
     {field_settings, action_settings} = transform_options(dsl_state)
 
     bypass = Info.bypass(dsl_state)
+    bypass_roles_field = Info.bypass_roles_field(dsl_state)
 
     {:ok,
      case Info.public?(dsl_state) do
@@ -20,7 +21,7 @@ defmodule AshRbac.Policies do
          dsl_state
          |> add_field_policies(field_settings)
          |> add_action_policies(action_settings)
-         |> add_bypass(bypass)
+         |> add_bypass(bypass, bypass_roles_field)
 
        true ->
          dsl_state
@@ -107,18 +108,18 @@ defmodule AshRbac.Policies do
     |> Enum.into(%{}, fn {roles, fields} -> {List.flatten(fields), List.flatten(roles)} end)
   end
 
-  defp add_bypass(dsl_state, nil), do: dsl_state
+  defp add_bypass(dsl_state, nil, _), do: dsl_state
 
-  defp add_bypass(dsl_state, role),
-    do: dsl_state |> add_field_bypass(role) |> add_action_bypass(role)
+  defp add_bypass(dsl_state, role, roles_field),
+    do: dsl_state |> add_field_bypass(role, roles_field) |> add_action_bypass(role, roles_field)
 
-  defp add_field_bypass(dsl_state, role) do
+  defp add_field_bypass(dsl_state, role, roles_field) do
     {:ok, check} =
       Transformer.build_entity(
         Ash.Policy.Authorizer,
         [:field_policies, :field_policy_bypass],
         :authorize_if,
-        check: {AshRbac.HasRole, [role: [roles: role]]}
+        check: {AshRbac.HasRole, [role: [{roles_field, role}]]}
       )
 
     {:ok, policy} =
@@ -132,7 +133,7 @@ defmodule AshRbac.Policies do
     |> Transformer.add_entity([:field_policies], policy, type: :prepend)
   end
 
-  defp add_action_bypass(dsl_state, role) do
+  defp add_action_bypass(dsl_state, role, roles_field) do
     {:ok, check} =
       Transformer.build_entity(Ash.Policy.Authorizer, [:policies, :bypass], :authorize_if,
         check: Builtins.always()
@@ -140,7 +141,7 @@ defmodule AshRbac.Policies do
 
     {:ok, policy} =
       Transformer.build_entity(Ash.Policy.Authorizer, [:policies], :bypass,
-        condition: [{AshRbac.HasRole, [role: [roles: role]]}],
+        condition: [{AshRbac.HasRole, [role: [{roles_field, role}]]}],
         policies: [check]
       )
 

--- a/lib/ash_rbac/role.ex
+++ b/lib/ash_rbac/role.ex
@@ -2,5 +2,5 @@ defmodule AshRbac.Role do
   @moduledoc """
   The Role entity for the DSL of the rbac extension
   """
-  defstruct [:role, :fields, :actions]
+  defstruct [:role, :options, :fields, :actions]
 end

--- a/lib/ash_rbac/role.ex
+++ b/lib/ash_rbac/role.ex
@@ -2,5 +2,5 @@ defmodule AshRbac.Role do
   @moduledoc """
   The Role entity for the DSL of the rbac extension
   """
-  defstruct [:role, :options, :fields, :actions]
+  defstruct [:role, :roles_field, :fields, :actions]
 end


### PR DESCRIPTION
This PR adds support for other roles fields in a resource by adding an option called `roles_field` so the user can customize it.

Usage example:

```elixir
role :employee, roles_field: :organization_roles do
  fields([:root_id, :created_at])

  actions [:read]
end
```

This PR is still a WIP, it doesn't handle `bypass` rules for example.